### PR TITLE
Add functionality to click palette name and show in generator

### DIFF
--- a/src/containers/Projects/Projects.js
+++ b/src/containers/Projects/Projects.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { storePalettes, storeProjects, setMessage } from '../../actions';
+import { storePalettes, storeProjects, setMessage, storeColors } from '../../actions';
 import closeButton from '../../assets/closeButton.png';
 import x from '../../assets/x.png';
 import { deletePalette } from '../../thunks/deletePalette';
@@ -69,7 +69,6 @@ export class Projects extends Component {
   
   addNewPalette = async () => {
     const { project_id, palette_name, color_1, color_2, color_3, color_4, color_5 } = this.state
-    console.log(project_id)
     const body = {
       project_id,
       palette_name,
@@ -81,6 +80,19 @@ export class Projects extends Component {
     }
     const options = await fetchOptionsCreator('POST', body)
     this.props.postNewPalette(options, body)
+  }
+
+  handleColorClick = (e) => {
+    const id = parseInt(e.target.id)
+    const foundPalette = this.props.palettes.find(palette => id === palette.palette_id)
+    const foundColors = [
+      { color: foundPalette.color_1, locked: false },
+      { color: foundPalette.color_2, locked: false },
+      { color: foundPalette.color_3, locked: false },
+      { color: foundPalette.color_4, locked: false },
+      { color: foundPalette.color_5, locked: false }
+    ]
+    this.props.storeColors(foundColors)
   }
 
   render() {
@@ -99,7 +111,7 @@ export class Projects extends Component {
             if (palette.project_id === project.project_id) {
               return <div className="project-palettes" key={`${palette.palette_name}-${index}`}>
                 <div className="palette-header">
-                  <h5>{palette.palette_name}</h5>
+                  <h5 onClick={this.handleColorClick} id={palette.palette_id} >{palette.palette_name}</h5>
                     <button onClick={this.deletePalette} >
                       <img className="delete-palette-button" src={closeButton} alt={'Delete Palette icon'} id={palette.palette_id}/>
                     </button>
@@ -179,7 +191,8 @@ export const mapDispatchToProps = (dispatch) => ({
   storeProjects: (updatedProjects) => dispatch(storeProjects(updatedProjects)),
   deleteProject: (id) => dispatch(deleteProject(id)),
   setMessage: (message) => dispatch(setMessage(message)),
-  postNewPalette: (options, body) => dispatch(postNewPalette(options, body))
+  postNewPalette: (options, body) => dispatch(postNewPalette(options, body)),
+  storeColors: (foundColors) => dispatch(storeColors(foundColors))
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(Projects)


### PR DESCRIPTION
#### Description:
When the user clicks on a palette name, the palette will generate in the palette generator.

#### Where should the reviewer start?
Projects.js line 85

#### Link to related issues:
#4 

#### Covered by tests:
- [ ] Yes
- [x] No

#### if NO, explain why:
Need to update testing

#### Final checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas

#### GIF of how this PR makes you feel:
![Fun and creative GIF](https://media.giphy.com/media/nLJQVncoUbH2M/giphy-downsized.gif)
